### PR TITLE
Add day trading example with ReAct planning agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,19 @@
 # explore_agent
+
 Exploring agents with Agno and Crew AI
+
+## Day Trading Example
+
+This repository now includes a simple example of building a multi-agent crew for day trading research and planning. The configuration lives in `day_trading_config.yaml` and defines:
+
+- A search agent that gathers information from Crewai documentation and SEBI regulations.
+- ReAct, planning and reflective agents that analyze the results and develop a strategy.
+- A day trading agent that performs paper trading using the generated plan.
+
+Run the crew with:
+
+```bash
+python run_day_trading_agents.py
+```
+
+This will execute the tasks sequentially and print the final simulated trading summary.

--- a/day_trading_config.yaml
+++ b/day_trading_config.yaml
@@ -1,0 +1,55 @@
+agents:
+  search_agent:
+    role: "Web Searcher"
+    goal: "Gather information from official documentation and market regulators."
+    backstory: "You specialize in using search tools to collect authoritative sources."
+
+  react_agent:
+    role: "ReAct Strategist"
+    goal: "Combine reasoning and actions to interpret search results."
+    backstory: "You analyze retrieved information step by step to form strategies."
+
+  planning_agent:
+    role: "Planning Agent"
+    goal: "Draft detailed day trading plans based on reliable data."
+    backstory: "You excel at structuring actionable plans for trading workflows."
+
+  reflective_agent:
+    role: "Reflective Reviewer"
+    goal: "Evaluate trading plans and suggest improvements."
+    backstory: "You think critically about strategies and refine them for better outcomes."
+
+  day_trading_agent:
+    role: "Day Trading Executor"
+    goal: "Simulate trades following SEBI guidelines."
+    backstory: "You perform paper trading and ensure compliance with regulations."
+
+tasks:
+  search_task:
+    description: "Search Crewai documentation and SEBI guidelines related to day trading."
+    assigned_agent: "search_agent"
+    expected_output: "Key points and references from official sources."
+
+  react_task:
+    description: "Use ReAct reasoning to derive insights from the search results."
+    assigned_agent: "react_agent"
+    depends_on: "search_task"
+    expected_output: "Reasoned approach for building a trading strategy."
+
+  planning_task:
+    description: "Plan a step-by-step day trading strategy using the ReAct insights."
+    assigned_agent: "planning_agent"
+    depends_on: "react_task"
+    expected_output: "A detailed trading plan."
+
+  reflection_task:
+    description: "Review the trading plan and refine it for effectiveness and compliance."
+    assigned_agent: "reflective_agent"
+    depends_on: "planning_task"
+    expected_output: "Improved trading plan with justifications."
+
+  trading_task:
+    description: "Execute the plan in a simulated environment following SEBI rules."
+    assigned_agent: "day_trading_agent"
+    depends_on: "reflection_task"
+    expected_output: "Summary of simulated trades and compliance notes."

--- a/run_day_trading_agents.py
+++ b/run_day_trading_agents.py
@@ -1,0 +1,57 @@
+import yaml
+from crewai import Agent, Task, Crew, Process
+from crewai_tools import SerperDevTool
+
+
+def load_config(path: str):
+    with open(path, "r") as f:
+        return yaml.safe_load(f)
+
+
+def create_agents(agent_defs):
+    search_tool = SerperDevTool()
+    agents = {}
+    for name, info in agent_defs.items():
+        tools = [search_tool] if name == "search_agent" else []
+        agents[name] = Agent(
+            role=info["role"],
+            goal=info["goal"],
+            backstory=info["backstory"],
+            tools=tools,
+            verbose=True,
+        )
+    return agents, search_tool
+
+
+def create_tasks(task_defs, agents, search_tool):
+    tasks = []
+    for name, info in task_defs.items():
+        tools = [search_tool] if info.get("assigned_agent") == "search_agent" else []
+        task = Task(
+            description=info["description"],
+            agent=agents[info["assigned_agent"]],
+            expected_output=info["expected_output"],
+            tools=tools,
+        )
+        tasks.append(task)
+    return tasks
+
+
+def main():
+    config = load_config("day_trading_config.yaml")
+    agents, search_tool = create_agents(config["agents"])
+    tasks = create_tasks(config["tasks"], agents, search_tool)
+
+    crew = Crew(
+        agents=list(agents.values()),
+        tasks=tasks,
+        process=Process.sequential,
+        verbose=True,
+    )
+
+    result = crew.kickoff()
+    print("\nFinal result:\n", result)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- document new day trading crew example in README
- add configuration for search, ReAct, planning, reflective and day trading agents
- provide script to run the crew using the YAML config

## Testing
- `python -m py_compile run_day_trading_agents.py`


------
https://chatgpt.com/codex/tasks/task_e_685c300fdc1883278b4fac69ed7bc80f