### PR TITLE
Add day-trading dashboard example

### DIFF
--- a/dashboard/README.md
+++ b/dashboard/README.md
@@ -1,0 +1,30 @@
+# Day-Trading Crew Dashboard
+
+This example shows a minimal dashboard stack for the day-trading crew using an Express backend and React frontend.
+
+## Architecture
+- **Express API** with JWT authentication and a WebSocket for trade updates.
+- **React** component that connects to the WebSocket and lists trades live.
+
+## Getting Started
+1. Install Node 18 or later and pnpm.
+2. Install server dependencies:
+   ```bash
+   cd dashboard/server
+   pnpm install
+   node server.js
+   ```
+3. In another terminal, install client deps and run a bundler of your choice:
+   ```bash
+   cd ../client
+   pnpm install
+   # integrate with your React setup (e.g., Vite)
+   ```
+
+The server exposes:
+- `POST /auth/login` – returns a JWT token when given `{username}`.
+- `GET /trades` – list trades (requires `Authorization: Bearer <token>`).
+- `POST /trades` – create a trade (requires auth; JSON body `{symbol, qty, price}`).
+- WebSocket at `ws://localhost:3000` broadcasting trade updates.
+
+Use the `TradeUpdates` React component to display live trades.

--- a/dashboard/client/package.json
+++ b/dashboard/client/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "day-trading-client",
+  "version": "1.0.0",
+  "type": "module",
+  "dependencies": {
+    "react": "^18.0.0",
+    "react-dom": "^18.0.0"
+  }
+}

--- a/dashboard/client/src/TradeUpdates.jsx
+++ b/dashboard/client/src/TradeUpdates.jsx
@@ -1,0 +1,26 @@
+import { useEffect, useState } from 'react';
+
+export default function TradeUpdates() {
+  const [trades, setTrades] = useState([]);
+
+  useEffect(() => {
+    const ws = new WebSocket('ws://localhost:3000');
+    ws.onmessage = (event) => {
+      const msg = JSON.parse(event.data);
+      if (msg.type === 'init') setTrades(msg.data);
+      if (msg.type === 'trade') setTrades(t => [...t, msg.data]);
+    };
+    return () => ws.close();
+  }, []);
+
+  return (
+    <div>
+      <h2>Live Trades</h2>
+      <ul>
+        {trades.map((t, i) => (
+          <li key={i}>{t.user}: {t.symbol} {t.qty} @ {t.price}</li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/dashboard/server/package.json
+++ b/dashboard/server/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "day-trading-server",
+  "version": "1.0.0",
+  "type": "module",
+  "main": "server.js",
+  "dependencies": {
+    "express": "^5.0.0",
+    "jsonwebtoken": "^9.0.0",
+    "ws": "^8.0.0"
+  }
+}

--- a/dashboard/server/server.js
+++ b/dashboard/server/server.js
@@ -1,0 +1,53 @@
+import express from 'express';
+import jwt from 'jsonwebtoken';
+import { WebSocketServer } from 'ws';
+
+const app = express();
+app.use(express.json());
+const SECRET = 'change_this_secret';
+
+// simple in-memory trade store
+const trades = [];
+
+function authMiddleware(req, res, next) {
+  const auth = req.headers.authorization;
+  if (!auth) return res.status(401).json({ error: 'missing token' });
+  const token = auth.split(' ')[1];
+  try {
+    req.user = jwt.verify(token, SECRET);
+    next();
+  } catch (err) {
+    res.status(401).json({ error: 'invalid token' });
+  }
+}
+
+app.post('/auth/login', (req, res) => {
+  const { username } = req.body;
+  const token = jwt.sign({ username }, SECRET, { expiresIn: '1h' });
+  res.json({ token });
+});
+
+app.get('/trades', authMiddleware, (req, res) => {
+  res.json(trades);
+});
+
+app.post('/trades', authMiddleware, (req, res) => {
+  const trade = { ...req.body, user: req.user.username, time: Date.now() };
+  trades.push(trade);
+  broadcast(JSON.stringify({ type: 'trade', data: trade }));
+  res.status(201).json(trade);
+});
+
+// WebSocket setup
+const server = app.listen(3000, () => console.log('API listening on 3000'));
+const wss = new WebSocketServer({ server });
+
+function broadcast(msg) {
+  wss.clients.forEach(client => {
+    if (client.readyState === client.OPEN) client.send(msg);
+  });
+}
+
+wss.on('connection', ws => {
+  ws.send(JSON.stringify({ type: 'init', data: trades }));
+});


### PR DESCRIPTION
## Summary
- create dashboard folder with server and client subfolders
- add Express server showing JWT auth and WebSocket trade feed
- add example React component for live trade updates
- document how to run the dashboard

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685c3332b1388327af853149e5ff97f1