### PR TITLE
Order day trading tasks based on dependency graph

### DIFF
--- a/run_day_trading_agents.py
+++ b/run_day_trading_agents.py
@@ -1,6 +1,7 @@
 import yaml
 from crewai import Agent, Task, Crew, Process
 from crewai_tools import SerperDevTool
+from collections import defaultdict, deque
 
 
 def load_config(path: str):
@@ -23,18 +24,50 @@ def create_agents(agent_defs):
     return agents, search_tool
 
 
+def _sort_task_names(task_defs):
+    indegree = {name: 0 for name in task_defs}
+    graph = defaultdict(list)
+
+    for name, info in task_defs.items():
+        deps = info.get("depends_on")
+        if not deps:
+            continue
+        if isinstance(deps, str):
+            deps = [deps]
+        for dep in deps:
+            if dep not in task_defs:
+                raise KeyError(f"Task '{name}' depends on undefined task '{dep}'")
+            graph[dep].append(name)
+            indegree[name] += 1
+
+    queue = deque([n for n, d in indegree.items() if d == 0])
+    ordered = []
+    while queue:
+        current = queue.popleft()
+        ordered.append(current)
+        for neighbor in graph.get(current, []):
+            indegree[neighbor] -= 1
+            if indegree[neighbor] == 0:
+                queue.append(neighbor)
+
+    if len(ordered) != len(task_defs):
+        raise ValueError("Cycle detected in task dependencies")
+    return ordered
+
+
 def create_tasks(task_defs, agents, search_tool):
-    tasks = []
+    task_objs = {}
     for name, info in task_defs.items():
         tools = [search_tool] if info.get("assigned_agent") == "search_agent" else []
-        task = Task(
+        task_objs[name] = Task(
             description=info["description"],
             agent=agents[info["assigned_agent"]],
             expected_output=info["expected_output"],
             tools=tools,
         )
-        tasks.append(task)
-    return tasks
+
+    ordered_names = _sort_task_names(task_defs)
+    return [task_objs[n] for n in ordered_names]
 
 
 def main():


### PR DESCRIPTION
## Summary
- ensure tasks are created respecting `depends_on`
- implement topological sort for task ordering

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68658dee13a48327867736e3a4931c78