### PR TITLE
Add client dashboard build setup

### DIFF
--- a/dashboard/README.md
+++ b/dashboard/README.md
@@ -14,12 +14,15 @@ This example shows a minimal dashboard stack for the day-trading crew using an E
    pnpm install
    node server.js
    ```
-3. In another terminal, install client deps and run a bundler of your choice:
+3. In another terminal, run the React client using Vite:
    ```bash
    cd ../client
    pnpm install
-   # integrate with your React setup (e.g., Vite)
+   pnpm run dev
    ```
+   The app reads `index.html` at the project root and mounts the exported `TradeUpdates`
+   and `DerivativesMastery` components. Build a production bundle with `pnpm run build`.
+   Tailwind CSS is configured in `tailwind.config.js` and included via `src/index.css`.
 
 The server exposes:
 - `POST /auth/login` – returns a JWT token when given `{username}`.

--- a/dashboard/client/index.html
+++ b/dashboard/client/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Day Trading Dashboard</title>
+  </head>
+  <body class="bg-gray-100">
+    <div id="root"></div>
+    <script type="module" src="/src/main.jsx"></script>
+  </body>
+</html>

--- a/dashboard/client/package.json
+++ b/dashboard/client/package.json
@@ -8,6 +8,13 @@
     "chart.js": "^4.4.1"
   },
   "devDependencies": {
-    "tailwindcss": "^3.4.1"
+    "tailwindcss": "^3.4.1",
+    "vite": "^5.0.0",
+    "autoprefixer": "^10.0.0",
+    "postcss": "^8.0.0"
+  },
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build"
   }
 }

--- a/dashboard/client/src/index.css
+++ b/dashboard/client/src/index.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/dashboard/client/src/main.jsx
+++ b/dashboard/client/src/main.jsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import { TradeUpdates, DerivativesMastery } from './index.js';
+import './index.css';
+
+ReactDOM.createRoot(document.getElementById('root')).render(
+  <React.StrictMode>
+    <div className="p-4 space-y-8">
+      <TradeUpdates />
+      <DerivativesMastery />
+    </div>
+  </React.StrictMode>
+);

--- a/dashboard/client/tailwind.config.js
+++ b/dashboard/client/tailwind.config.js
@@ -1,0 +1,7 @@
+export default {
+  content: ['./index.html', './src/**/*.{js,jsx,ts,tsx}'],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};


### PR DESCRIPTION
## Summary
- build `dashboard/client` with Vite and Tailwind
- mount React components in new `index.html`
- add `src/main.jsx` with Tailwind styles
- document running the client in the dashboard README

## Testing
- `pnpm --version`
- `pnpm install`
- `pnpm run build`

------
https://chatgpt.com/codex/tasks/task_e_6865949f0ee48327b37c056ceba66bd3