### PR TITLE
Allow configurable JWT secret

### DIFF
--- a/dashboard/README.md
+++ b/dashboard/README.md
@@ -12,6 +12,7 @@ This example shows a minimal dashboard stack for the day-trading crew using an E
    ```bash
    cd dashboard/server
    pnpm install
+   export JWT_SECRET=your_secret # set before starting the API
    node server.js
    ```
 3. In another terminal, run the React client using Vite:

--- a/dashboard/server/server.js
+++ b/dashboard/server/server.js
@@ -4,7 +4,9 @@ import { WebSocketServer } from 'ws';
 
 const app = express();
 app.use(express.json());
-const SECRET = 'change_this_secret';
+// Read JWT secret from env so deployments can override it. Fall back to a
+// predictable value for local development.
+const SECRET = process.env.JWT_SECRET || 'change_this_secret';
 
 // simple in-memory trade store
 const trades = [];


### PR DESCRIPTION
## Summary
- read `JWT_SECRET` from environment with a fallback
- document `JWT_SECRET` usage in dashboard README

## Testing
- `node --check dashboard/server/server.js`
- `python -m py_compile run_day_trading_agents.py`


------
https://chatgpt.com/codex/tasks/task_e_6865976722c48327bf986f6354c66fc5