### PR TITLE
Use env file for JWT secret

### DIFF
--- a/dashboard/README.md
+++ b/dashboard/README.md
@@ -7,12 +7,16 @@ This example shows a minimal dashboard stack for the day-trading crew using an E
 - **React** component that connects to the WebSocket and lists trades live.
 
 ## Getting Started
+The API requires a `JWT_SECRET` environment variable. Copy `server/.env.example`
+to `server/.env` and adjust the value before running the server.
 1. Install Node 18 or later and pnpm.
 2. Install server dependencies:
    ```bash
    cd dashboard/server
    pnpm install
-   export JWT_SECRET=your_secret # set before starting the API
+   # Set the JWT secret (required for signing tokens)
+   cp .env.example .env && \
+   export $(grep JWT_SECRET .env)
    node server.js
    ```
 3. In another terminal, run the React client using Vite:

--- a/dashboard/server/.env.example
+++ b/dashboard/server/.env.example
@@ -1,0 +1,1 @@
+JWT_SECRET=change_this_secret

--- a/dashboard/server/server.js
+++ b/dashboard/server/server.js
@@ -4,9 +4,11 @@ import { WebSocketServer } from 'ws';
 
 const app = express();
 app.use(express.json());
-// Read JWT secret from env so deployments can override it. Fall back to a
-// predictable value for local development.
-const SECRET = process.env.JWT_SECRET || 'change_this_secret';
+// Read JWT secret from environment. Throw if not provided.
+const SECRET = process.env.JWT_SECRET;
+if (!SECRET) {
+  throw new Error('JWT_SECRET environment variable is required');
+}
 
 // simple in-memory trade store
 const trades = [];


### PR DESCRIPTION
## Summary
- move `.env.example` into the server directory
- document copying it before running the dashboard API

## Testing
- `pnpm install`
- `cp .env.example .env && export $(grep JWT_SECRET .env) && node server.js`

------
https://chatgpt.com/codex/tasks/task_e_68659b963f048327a6b550ddf76ba62f