### PR TITLE
Implement JWT auth for WebSocket

### DIFF
--- a/dashboard/client/src/TradeUpdates.jsx
+++ b/dashboard/client/src/TradeUpdates.jsx
@@ -4,7 +4,10 @@ export default function TradeUpdates() {
   const [trades, setTrades] = useState([]);
 
   useEffect(() => {
-    const ws = new WebSocket('ws://localhost:3000');
+    const token = localStorage.getItem('token');
+    const url = token ? `ws://localhost:3000?token=${token}` : 'ws://localhost:3000';
+    const protocols = token ? [token] : undefined;
+    const ws = new WebSocket(url, protocols);
     ws.onmessage = (event) => {
       const msg = JSON.parse(event.data);
       if (msg.type === 'init') setTrades(msg.data);

--- a/dashboard/server/server.js
+++ b/dashboard/server/server.js
@@ -1,6 +1,6 @@
 import express from 'express';
 import jwt from 'jsonwebtoken';
-import { WebSocketServer } from 'ws';
+import { WebSocketServer, WebSocket } from 'ws';
 
 const app = express();
 app.use(express.json());
@@ -46,10 +46,30 @@ const wss = new WebSocketServer({ server });
 
 function broadcast(msg) {
   wss.clients.forEach(client => {
-    if (client.readyState === client.OPEN) client.send(msg);
+    if (client.readyState === WebSocket.OPEN) {
+      client.send(msg);
+    }
   });
 }
 
-wss.on('connection', ws => {
+wss.on('connection', (ws, req) => {
+  let token;
+  try {
+    const url = new URL(req.url, 'http://localhost');
+    token = url.searchParams.get('token');
+
+    if (!token && req.headers['sec-websocket-protocol']) {
+      token = req.headers['sec-websocket-protocol'].split(',')[0].trim();
+    }
+
+    if (!token) throw new Error('missing token');
+
+    const user = jwt.verify(token, SECRET);
+    ws.user = user;
+  } catch (err) {
+    ws.close(1008, 'invalid token');
+    return;
+  }
+
   ws.send(JSON.stringify({ type: 'init', data: trades }));
 });


### PR DESCRIPTION
## Summary
- secure trade updates WebSocket with JWT authentication
- include token when establishing WebSocket connection from client
- add check for missing token and use `WebSocket.OPEN` constant

## Testing
- `pnpm install` in `dashboard/server`
- `pnpm install` in `dashboard/client`
- `node dashboard/server/server.js` *(prints "API listening on 3000")*

------
https://chatgpt.com/codex/tasks/task_e_68659b98a00483279b02b5d2b48450b1